### PR TITLE
fix: remove ignore_changes on container_definitions (INF-1879)

### DIFF
--- a/README.md
+++ b/README.md
@@ -263,7 +263,7 @@ allow_github_webhooks        = true
 ## Requirements
 
 | Name | Version |
-|------|---------|
+| ---- | ------- |
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.1 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.69 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | >= 2.0 |
@@ -271,14 +271,14 @@ allow_github_webhooks        = true
 ## Providers
 
 | Name | Version |
-|------|---------|
+| ---- | ------- |
 | <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.69 |
 | <a name="provider_random"></a> [random](#provider\_random) | >= 2.0 |
 
 ## Modules
 
 | Name | Source | Version |
-|------|--------|---------|
+| ---- | ------ | ------- |
 | <a name="module_acm"></a> [acm](#module\_acm) | terraform-aws-modules/acm/aws | v3.2.0 |
 | <a name="module_alb"></a> [alb](#module\_alb) | terraform-aws-modules/alb/aws | v6.5.0 |
 | <a name="module_alb_http_sg"></a> [alb\_http\_sg](#module\_alb\_http\_sg) | terraform-aws-modules/security-group/aws//modules/http-80 | v4.3.0 |
@@ -291,7 +291,7 @@ allow_github_webhooks        = true
 ## Resources
 
 | Name | Type |
-|------|------|
+| ---- | ---- |
 | [aws_cloudwatch_log_group.atlantis](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_log_group) | resource |
 | [aws_ecs_service.atlantis](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ecs_service) | resource |
 | [aws_ecs_task_definition.atlantis](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ecs_task_definition) | resource |
@@ -322,7 +322,7 @@ allow_github_webhooks        = true
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|------|---------|:--------:|
+| ---- | ----------- | ---- | ------- | :------: |
 | <a name="input_acm_certificate_domain_name"></a> [acm\_certificate\_domain\_name](#input\_acm\_certificate\_domain\_name) | Route53 domain name to use for ACM certificate. Route53 zone for this domain should be created in advance. Specify if it is different from value in `route53_zone_name` | `string` | `""` | no |
 | <a name="input_alb_authenticate_cognito"></a> [alb\_authenticate\_cognito](#input\_alb\_authenticate\_cognito) | Map of AWS Cognito authentication parameters to protect ALB (eg, using SAML). See https://www.terraform.io/docs/providers/aws/r/lb_listener.html#authenticate-cognito-action | `any` | `{}` | no |
 | <a name="input_alb_authenticate_oidc"></a> [alb\_authenticate\_oidc](#input\_alb\_authenticate\_oidc) | Map of Authenticate OIDC parameters to protect ALB (eg, using Auth0). See https://www.terraform.io/docs/providers/aws/r/lb_listener.html#authenticate-oidc-action | `any` | `{}` | no |
@@ -445,7 +445,7 @@ allow_github_webhooks        = true
 ## Outputs
 
 | Name | Description |
-|------|-------------|
+| ---- | ----------- |
 | <a name="output_alb_arn"></a> [alb\_arn](#output\_alb\_arn) | ARN of alb |
 | <a name="output_alb_dns_name"></a> [alb\_dns\_name](#output\_alb\_dns\_name) | Dns name of alb |
 | <a name="output_alb_http_listeners_arn"></a> [alb\_http\_listeners\_arn](#output\_alb\_http\_listeners\_arn) | ARNs of alb http listeners |

--- a/main.tf
+++ b/main.tf
@@ -703,13 +703,6 @@ resource "aws_ecs_task_definition" "atlantis" {
     }
   }
 
-  lifecycle {
-    ignore_changes = [
-      # TODO: nipper-2022-DEC-13 Figure out why container_definitions is triggering changes
-      container_definitions,
-    ]
-  }
-
   tags = local.tags
 }
 


### PR DESCRIPTION
## Summary

- Removes the `lifecycle { ignore_changes = [container_definitions] }` block on `aws_ecs_task_definition.atlantis` so that changes to the container image (and other container settings) are actually picked up by Terraform plan/apply.
- README regenerated by the `terraform-docs` pre-commit hook (table separator formatting only; no content changes).

## Why

This `ignore_changes` was added as a TODO workaround back in 2022 to silence spurious drift, but it also silently swallows legitimate changes — including version bumps to the Atlantis container image.

While working on the Atlantis upgrade to `v0.42.0` (to fix the expired HashiCorp GPG key breaking all Terraform downloads — see [runatlantis/atlantis#6405](https://github.com/runatlantis/atlantis/issues/6405)), we discovered that `terraform plan` showed **no changes** even after bumping `atlantis_version`. The `ignore_changes` on `container_definitions` was the cause.

## Follow-up

If drift reappears on `container_definitions` after this change lands, we will open a new ticket to investigate the root cause (likely AWS-side JSON normalization) rather than using a blanket ignore.

## Jira

- [INF-1879](https://keends.atlassian.net/browse/INF-1879)

[INF-1879]: https://keends.atlassian.net/browse/INF-1879?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ